### PR TITLE
Task #83 - Added react-select to select resource for timesheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"react-modal": "^3.16.3",
 		"react-query": "^3.39.3",
 		"react-router-dom": "^6.8.2",
+		"react-select": "^5.10.1",
 		"react-toastify": "^11.0.5",
 		"react-tooltip": "^5.28.1",
 		"typescript": "^5.8.3",

--- a/src/components/timesheet/Krm3Calendar.tsx
+++ b/src/components/timesheet/Krm3Calendar.tsx
@@ -8,8 +8,10 @@ import EditDayEntry from "./edit-entry/EditDayEntry";
 import VisualizationActions from "./VisualizationActions";
 import { useColumnViewPreference } from "../../hooks/useView";
 import { formatDate, formatDayAndMonth, formatMonthName } from "./utils/dates";
+import { useGetCurrentUser } from "../../hooks/useAuth";
+import ErrorMessage from "./edit-entry/ErrorMessage";
 
-export default function Krm3Calendar() {
+export default function Krm3Calendar({ selectedResourceId }: { selectedResourceId: number | null }) {
   const [selectedCells, setSelectedCells] = useState<Date[] | undefined>();
   const [selectedTask, setSelectedTask] = useState<Task | undefined>(undefined);
   const [timeEntries, setTimeEntries] = useState<TimeEntry[]>([]);
@@ -25,6 +27,48 @@ export default function Krm3Calendar() {
     const diff = today.getDate() - day + (day === 0 ? -6 : 1);
     return new Date(today.setDate(diff));
   });
+
+  const { data, userCan } = useGetCurrentUser();
+
+  const isEditViewAnotherUser = useMemo(() => {
+    return data?.resource?.id !== selectedResourceId;
+  }, [data?.resource?.id, selectedResourceId]);
+
+  const readOnlyPermission = useMemo(() => {
+    if (!isEditViewAnotherUser) {
+      return true;
+    }
+    return userCan([
+      "core.manage_any_project",
+      "core.view_any_timesheet"
+    ]) || userCan([
+      "core.view_any_project",
+      "core.view_any_timesheet"
+    ]);
+  }, [userCan, isEditViewAnotherUser]);
+
+  const readWritePermission = useMemo(() => {
+    if (!isEditViewAnotherUser) {
+      return true;
+    }
+    return userCan([
+      "core.manage_any_project",
+      "core.manage_any_timesheet"
+    ]) || userCan([
+      "core.view_any_project",
+      "core.manage_any_timesheet"
+    ]);
+  }, [userCan, isEditViewAnotherUser]);
+
+  const accessDenied = useMemo(() => {
+    return !readOnlyPermission && !readWritePermission;
+  }, [readOnlyPermission, readWritePermission]);
+
+  const readOnly = useMemo(() => {
+    return readOnlyPermission && !readWritePermission;
+  }, [readOnlyPermission, readWritePermission]);
+
+
 
   const currentMonth = useMemo(() => {
     // currentWeekStart.getMonth();
@@ -66,7 +110,7 @@ export default function Krm3Calendar() {
   const isToday =
     currentWeekStart <= new Date() &&
     new Date() <=
-      new Date(currentWeekStart.getTime() + 6 * 24 * 60 * 60 * 1000);
+    new Date(currentWeekStart.getTime() + 6 * 24 * 60 * 60 * 1000);
 
   const navigatePrev = () => {
     const newDate = new Date(currentWeekStart);
@@ -89,114 +133,127 @@ export default function Krm3Calendar() {
   };
 
   return (
-    <div  id="krm3-calendar-container">
-      <div className="flex justify-between">
-        <div
-          className="flex  items-center justify-between min-w-[180px]"
-          id="calendar-navigation"
-        >
-          <button
-            id="nav-prev-btn"
-            onClick={navigatePrev}
-            className="cursor-pointer"
-          >
-            <ChevronLeft />
-          </button>
-          <span className="font-medium" id="date-range-display">
-            {isMonth
-              ? formatMonthName(scheduledDays.days[0])
-              : `${formatDayAndMonth(scheduledDays.days[0])} - ${formatDayAndMonth(
-                  scheduledDays.days[6]
-                )}`}
-          </span>
-          <button
-            onClick={navigateNext}
-            className="cursor-pointer"
-            id="nav-next-btn"
-          >
-            <ChevronRight />
-          </button>
-        </div>
-        <button
-          id="today-btn"
-          onClick={() =>
-            setCurrentWeekStart(() => {
-              const today = new Date();
-              const day = today.getDay();
-              const diff = today.getDate() - day + (day === 0 ? -6 : 1);
-              return new Date(today.setDate(diff));
-            })
-          }
-          className={`${
-            isToday ? "bg-gray-500 cursor-not-allowed " : "bg-yellow-500"
-          } rounded px-4 py-2  text-white `}
-          disabled={isToday}
-        >
-          {isMonth ? "This month" : "This week"}
-        </button>
-      </div>
-      <VisualizationActions
-        isMonth={isMonth}
-        setIsMonth={setIsMonth}
-        isColumnView={isColumnView}
-        setColumnView={setColumnView}
-      />
-      <TimeSheetTable
-        isColumnView={isColumnView}
-        setOpenTimeEntryModal={setOpenTimeEntryModal}
-        setSelectedTask={setSelectedTask}
-        setTimeEntries={setTimeEntries}
-        setSelectedCells={setSelectedCells}
-        setIsDayEntry={setIsDayEntry}
-        setStartDate={setStartDate}
-        setEndDate={setEndDate}
-        scheduleDays={scheduledDays}
-        startDate={startDate}
-        endDate={endDate}
-      />
-      {openTimeEntryModal &&
-        selectedTask &&
-        startDate &&
-        endDate && (
-          <Krm3Modal
-            open={openTimeEntryModal}
-            onClose={() => {
-              setOpenTimeEntryModal(false);
-              setSelectedCells(undefined);
-            }}
-            children={
-              <>
-                {isDayEntry ? (
-                  <EditDayEntry
-                    onClose={() => {
-                      setOpenTimeEntryModal(false);
-                      setSelectedCells(undefined);
-                    }}
-                    startDate={startDate}
-                    endDate={endDate}
-                    timeEntries={timeEntries}
-                  />
-                ) : (
-                  <EditTimeEntry
-                    startDate={startDate}
-                    endDate={endDate}
-                    task={selectedTask}
-                    timeEntries={timeEntries}
-                    closeModal={() => {
-                      setOpenTimeEntryModal(false);
-                      setSelectedCells(undefined);
-                    }}
-                  />
-                )}
-              </>
-            }
-            title={
-              isDayEntry
-                ? "Day Entry"
-                : `Add Time Entry for ${selectedTask.title}`
-            }
-          />
+    <>
+      {accessDenied ? (
+        <ErrorMessage message="Access Denied. You don't have permissions to View/Edit timesheet" />
+      ) :
+        (
+          <div id="krm3-calendar-container">
+            <div className="flex justify-between">
+              <div
+                className="flex  items-center justify-between min-w-[180px]"
+                id="calendar-navigation"
+              >
+                <button
+                  id="nav-prev-btn"
+                  onClick={navigatePrev}
+                  className="cursor-pointer"
+                >
+                  <ChevronLeft />
+                </button>
+                <span className="font-medium" id="date-range-display">
+                  {isMonth
+                    ? formatMonthName(scheduledDays.days[0])
+                    : `${formatDayAndMonth(scheduledDays.days[0])} - ${formatDayAndMonth(
+                      scheduledDays.days[6]
+                    )}`}
+                </span>
+                <button
+                  onClick={navigateNext}
+                  className="cursor-pointer"
+                  id="nav-next-btn"
+                >
+                  <ChevronRight />
+                </button>
+              </div>
+              <button
+                id="today-btn"
+                onClick={() =>
+                  setCurrentWeekStart(() => {
+                    const today = new Date();
+                    const day = today.getDay();
+                    const diff = today.getDate() - day + (day === 0 ? -6 : 1);
+                    return new Date(today.setDate(diff));
+                  })
+                }
+                className={`${isToday ? "bg-gray-500 cursor-not-allowed " : "bg-yellow-500"
+                  } rounded px-4 py-2  text-white `}
+                disabled={isToday}
+              >
+                {isMonth ? "This month" : "This week"}
+              </button>
+            </div>
+            <VisualizationActions
+              isMonth={isMonth}
+              setIsMonth={setIsMonth}
+              isColumnView={isColumnView}
+              setColumnView={setColumnView}
+            />
+            <TimeSheetTable
+              isColumnView={isColumnView}
+              setOpenTimeEntryModal={setOpenTimeEntryModal}
+              setSelectedTask={setSelectedTask}
+              setTimeEntries={setTimeEntries}
+              setSelectedCells={setSelectedCells}
+              setIsDayEntry={setIsDayEntry}
+              setStartDate={setStartDate}
+              setEndDate={setEndDate}
+              scheduleDays={scheduledDays}
+              startDate={startDate}
+              endDate={endDate}
+              selectedResourceId={selectedResourceId}
+              readOnly={readOnly}
+            />
+            {openTimeEntryModal &&
+              selectedTask &&
+              startDate &&
+              endDate && (
+                <Krm3Modal
+                  open={openTimeEntryModal}
+                  onClose={() => {
+                    setOpenTimeEntryModal(false);
+                    setSelectedCells(undefined);
+                  }}
+                  children={
+                    <>
+                      {isDayEntry ? (
+                        <EditDayEntry
+                          onClose={() => {
+                            setOpenTimeEntryModal(false);
+                            setSelectedCells(undefined);
+                          }}
+                          startDate={startDate}
+                          endDate={endDate}
+                          timeEntries={timeEntries}
+                          readOnly={readOnly}
+                          selectedResourceId={selectedResourceId}
+                        />
+                      ) : (
+                        <EditTimeEntry
+                          startDate={startDate}
+                          endDate={endDate}
+                          task={selectedTask}
+                          timeEntries={timeEntries}
+                          closeModal={() => {
+                            setOpenTimeEntryModal(false);
+                            setSelectedCells(undefined);
+                          }}
+                          readOnly={readOnly}
+                          selectedResourceId={selectedResourceId}
+                        />
+                      )}
+                    </>
+                  }
+                  title={
+                    isDayEntry
+                      ? "Day Entry"
+                      : `${readOnly ? "View" : "Add"} Time Entry for ${selectedTask.title}`
+                  }
+                />
+              )}
+          </div>
         )}
-    </div>
+
+    </>
   );
 }

--- a/src/components/timesheet/SelectResource.tsx
+++ b/src/components/timesheet/SelectResource.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+import Select, { SingleValue } from 'react-select';
+import { useGetCurrentUser } from "../../hooks/useAuth";
+import { useGetActiveResources } from "../../hooks/useMissions";
+
+
+const SelectResourceComponent = ({ setSelectedResourceId }: { setSelectedResourceId: (id: number | null) => void }) => {
+
+    const resources = useGetActiveResources();
+    const { data } = useGetCurrentUser();
+
+    const getSelectOptions = () => {
+        if (!resources) return [];
+        return resources.map(resource => ({
+            value: resource.id,
+            label: `${resource.firstName} ${resource.lastName}`
+        }));
+    };
+
+    useEffect(() => {
+        // If no resource is selected, set the current user's resource as default
+        // TODO Handle the case in which the current user does not have a resource
+        if (data?.resource?.id) {
+            setSelectedResourceId(data.resource.id);
+        }
+    }, [data]);
+
+
+    const handleResourceChange = (selectedOption: SingleValue<{ value: number; label: string }>) => {
+        setSelectedResourceId(selectedOption ? selectedOption.value : null);
+    };
+
+    return (
+        <>
+            {resources && resources.length > 0 ? (
+                <>
+                <div className="mb-4">
+                    <label htmlFor="resource-select">Select Resource:</label><br />
+                    <Select
+                        onChange={handleResourceChange}
+                        options={getSelectOptions()}
+                        isClearable
+                        placeholder="Select a resource"
+                        id="resource-select"
+                        isSearchable
+                        defaultValue={data?.resource ? { value: data.resource.id, label: `${data.resource.firstName} ${data.resource.lastName}` } : null}
+                    />
+                </div>
+                </>
+            ) : null}
+        </>
+    );
+}
+
+export default SelectResourceComponent;

--- a/src/components/timesheet/TimesheetTable.tsx
+++ b/src/components/timesheet/TimesheetTable.tsx
@@ -28,6 +28,8 @@ interface Props {
   isColumnView: boolean;
   startDate?: Date;
   endDate?: Date;
+  selectedResourceId: number | null;
+  readOnly: boolean;
 }
 
 export function TimeSheetTable(props: Props) {
@@ -39,7 +41,8 @@ export function TimeSheetTable(props: Props) {
 
   const { data: timesheet, isLoading: isLoadingTimesheet } = useGetTimesheet(
     startScheduled,
-    endScheduled
+    endScheduled,
+    props.selectedResourceId
   );
 
   const [openShortMenu, setOpenShortMenu] = useState<
@@ -217,6 +220,8 @@ export function TimeSheetTable(props: Props) {
                 openTimeEntryModalHandler={openTimeEntryModalHandler}
                 openShortMenu={openShortMenu}
                 setOpenShortMenu={setOpenShortMenu}
+                readOnly={props.readOnly}
+                selectedResourceId={props.selectedResourceId}
               />
             ))
           )}

--- a/src/components/timesheet/edit-entry/EditDayEntry.tsx
+++ b/src/components/timesheet/edit-entry/EditDayEntry.tsx
@@ -23,6 +23,8 @@ interface Props {
   endDate: Date;
   timeEntries: TimeEntry[];
   onClose: () => void;
+  readOnly: boolean;
+  selectedResourceId: number | null;
 }
 
 export default function EditDayEntry({
@@ -30,13 +32,15 @@ export default function EditDayEntry({
   startDate,
   endDate,
   timeEntries,
+  readOnly,
+  selectedResourceId
 }: Props) {
   const {
     mutateAsync: submitDays,
     isLoading,
     isError,
     error,
-  } = useCreateTimeEntry();
+  } = useCreateTimeEntry(selectedResourceId);
   const { mutateAsync: deleteDays } = useDeleteTimeEntries();
   const startEntry = timeEntries.find(
     (item) => normalizeDate(item.date) === normalizeDate(startDate)
@@ -108,6 +112,7 @@ export default function EditDayEntry({
   }
 
   const handleEntryTypeChange = (type: string) => {
+    if (readOnly) return; // Prevent changes in read-only mode
     setEntryType(type);
     if (type !== "leave") {
       setLeaveHours(undefined); // Clear leave hours if not leave
@@ -168,7 +173,7 @@ export default function EditDayEntry({
           <div className="flex flex-wrap" id="datepickers">
             <div className="w-full md:w-1/3  mb-4 md:mb-0">
               <label className="block text-sm font-medium mb-1">
-                Dal giorno:
+                From day:
               </label>
               <DatePicker
                 dateFormat="yyyy-MM-dd"
@@ -180,11 +185,12 @@ export default function EditDayEntry({
                     handleChangeDate(date, "from");
                   }
                 }}
+                disabled={readOnly}
               />
             </div>
             <div className="w-full md:w-1/3 mb-4 md:mb-0">
               <label className="block text-sm font-medium mb-1">
-                Al giorno:
+                To day:
               </label>
               <DatePicker
                 dateFormat="yyyy-MM-dd"
@@ -196,6 +202,7 @@ export default function EditDayEntry({
                     handleChangeDate(date, "to");
                   }
                 }}
+                disabled={readOnly}
               />
             </div>
           </div>
@@ -305,6 +312,7 @@ export default function EditDayEntry({
                 required
                 className="w-full border  border-gray-300 rounded-md p-2"
                 placeholder="Enter hours"
+                disabled={readOnly}
               />
             </div>
           )}
@@ -324,6 +332,7 @@ export default function EditDayEntry({
                   value={specialReason}
                   onChange={(e) => setSpecialReason(e.target.value)}
                   className="w-full border   border-gray-300 rounded-md p-2"
+                  disabled={readOnly}
                 >
                   <option value=""> Select a reason</option>
                   {specialReasonOptions.map((reason, idx) => (
@@ -353,6 +362,7 @@ export default function EditDayEntry({
             value={comment || ""}
             required={entryType === "sick"}
             onChange={(e) => setComment(e.target.value)}
+            disabled={readOnly}
           ></textarea>
         </div>
 
@@ -373,7 +383,7 @@ export default function EditDayEntry({
 
         <div className="flex items-center justify-between pt-6 border-t border-gray-200">
           <Krm3Button
-            disabled={daysWithTimeEntries.length === 0}
+            disabled={daysWithTimeEntries.length === 0 || readOnly}
             type="button"
             style="danger"
             onClick={handleDeleteEntry}
@@ -390,7 +400,7 @@ export default function EditDayEntry({
             />
 
             <Krm3Button
-              disabled={isLoading || !entryType || !!leaveHoursError}
+              disabled={isLoading || !entryType || !!leaveHoursError || readOnly}
               type="submit"
               style="primary"
               label="Save"

--- a/src/components/timesheet/edit-entry/EditTimeEntry.tsx
+++ b/src/components/timesheet/edit-entry/EditTimeEntry.tsx
@@ -20,6 +20,8 @@ interface Props {
   startDate: Date;
   endDate: Date;
   closeModal: () => void;
+  readOnly: boolean;
+  selectedResourceId: number | null;
 }
 
 export default function EditTimeEntry({
@@ -28,6 +30,8 @@ export default function EditTimeEntry({
   closeModal,
   startDate,
   endDate,
+  readOnly,
+  selectedResourceId,
 }: Props) {
   const startEntry = timeEntries.find(
     (item) => item.date === normalizeDate(startDate) && item.task == task.id
@@ -69,9 +73,9 @@ export default function EditTimeEntry({
   const [totalHours, setTotalHours] = useState(
     startEntry
       ? Number(startEntry.dayShiftHours) +
-          Number(startEntry.nightShiftHours) +
-          Number(startEntry.travelHours) +
-          Number(startEntry.onCallHours)
+      Number(startEntry.nightShiftHours) +
+      Number(startEntry.travelHours) +
+      Number(startEntry.onCallHours)
       : 0
   ); // SHOULD ON CALL HOURS BE ADDED TO TOTAL HOURS???
 
@@ -98,7 +102,7 @@ export default function EditTimeEntry({
     isLoading,
   } = useDeleteTimeEntries();
   const { mutateAsync: createTimeEntries, error: creationError } =
-    useCreateTimeEntry();
+    useCreateTimeEntry(selectedResourceId);
 
   function getDatesToSave() {
     if (keepEntries) {
@@ -165,6 +169,7 @@ export default function EditTimeEntry({
                   handleChangeDate(date, "from");
                 }
               }}
+              disabled={readOnly}
             />
           </div>
           <div>
@@ -181,6 +186,7 @@ export default function EditTimeEntry({
                   handleChangeDate(date, "to");
                 }
               }}
+              disabled={readOnly}
             />
           </div>
         </div>
@@ -225,6 +231,7 @@ export default function EditTimeEntry({
                   Number(e.target.value) + nightShiftHours + travelHours
                 );
               }}
+              disabled={readOnly}
             />
           </div>
 
@@ -247,6 +254,7 @@ export default function EditTimeEntry({
                   Number(e.target.value) + dayShiftHours + travelHours
                 );
               }}
+              disabled={readOnly}
             />
           </div>
 
@@ -269,6 +277,7 @@ export default function EditTimeEntry({
                   dayShiftHours + Number(e.target.value) + nightShiftHours
                 );
               }}
+              disabled={readOnly}
             />
           </div>
 
@@ -288,6 +297,7 @@ export default function EditTimeEntry({
               onChange={(e) => {
                 setOnCallHours(Number(e.target.value));
               }}
+              disabled={readOnly}
             />
           </div>
         </div>
@@ -310,14 +320,17 @@ export default function EditTimeEntry({
           onChange={(e) => {
             setComment(e.target.value);
           }}
+          disabled={readOnly}
         />
       </div>
-      <WarningExistingEntry
-        daysWithTimeEntries={daysWithTimeEntries}
-        keepEntries={keepEntries}
-        setKeepEntries={setKeepEntries}
-        isCheckbox
-      />
+      {!readOnly && (
+        <WarningExistingEntry
+          daysWithTimeEntries={daysWithTimeEntries}
+          keepEntries={keepEntries}
+          setKeepEntries={setKeepEntries}
+          isCheckbox
+        />
+      )}
       {totalHours > 24 && (
         <ErrorMessage message="Total hours cannot exceed 24 hours per day." />
       )}
@@ -334,7 +347,7 @@ export default function EditTimeEntry({
         className="flex items-center justify-between pt-6 border-t border-gray-200"
       >
         <Krm3Button
-          disabled={daysWithTimeEntries.length === 0}
+          disabled={daysWithTimeEntries.length === 0 || readOnly}
           type="button"
           style="danger"
           onClick={handleDeleteEntries}
@@ -351,7 +364,7 @@ export default function EditTimeEntry({
             label="Cancel"
           />
           <Krm3Button
-            disabled={totalHours > 24 || totalHours === 0}
+            disabled={totalHours > 24 || totalHours === 0 || readOnly}
             type="submit"
             style="primary"
             label="Save"

--- a/src/components/timesheet/timesheet-row/ShortHoursMenu.tsx
+++ b/src/components/timesheet/timesheet-row/ShortHoursMenu.tsx
@@ -2,12 +2,14 @@ import { toast } from "react-toastify";
 import { useCreateTimeEntry } from "../../../hooks/useTimesheet";
 import { displayErrorMessage } from "../utils/utils";
 import { formatDate, getDatesBetween, normalizeDate } from "../utils/dates";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 export const ShortHoursMenu = (props: {
   day: Date;
   taskId: number;
-  openShortMenu?: {startDate: string; endDate: string; taskId: string };
+  openShortMenu?: { startDate: string; endDate: string; taskId: string };
+  readOnly: boolean;
+  selectedResourceId: number | null;
   setOpenShortMenu?: (
     value: { startDate: string; endDate: string; taskId: string } | undefined
   ) => void;
@@ -17,22 +19,27 @@ export const ShortHoursMenu = (props: {
     !!props.openShortMenu &&
     normalizeDate(props.openShortMenu.endDate) === normalizeDate(props.day) &&
     Number(props.openShortMenu.taskId) === props.taskId;
-  const { mutateAsync: createTimeEntries, error } = useCreateTimeEntry();
+  const { mutateAsync: createTimeEntries, error } = useCreateTimeEntry(props.selectedResourceId);
   const selectedDates = getDatesBetween(
     formatDate(props.openShortMenu?.startDate || ''),
     formatDate(props.openShortMenu?.endDate || ''),
   );
   const [isMenuRight, setIsMenuRight] = useState(true);
 
-  const options = [
-    { label: "2h", value: 2 },
-    { label: "4h", value: 4 },
-    { label: "8h", value: 8 },
-    { label: "More", value: 0 },
-  ];
+  const options = useMemo(() => {
+    if (props.readOnly) {
+      return [{ label: "Details", value: 0 }];
+    }
+    return [
+      { label: "2h", value: 2 },
+      { label: "4h", value: 4 },
+      { label: "8h", value: 8 },
+      { label: "More", value: 0 },
+    ];
+  }, [props.readOnly]);
 
   function handleButtonClick(label: string, value: number) {
-    if (label === "More") {
+    if (value === 0) {
       props.openTimeEntryModalHandler();
     } else {
       toast.promise(
@@ -62,13 +69,11 @@ export const ShortHoursMenu = (props: {
   return (
     <div
       onMouseLeave={() => props.setOpenShortMenu?.(undefined)}
-      className={`absolute z-50 ${
-        isMenuRight ? "right-0" : "left-0"
-      } mt-2 w-56 origin-top-right bg-white divide-y divide-gray-100 rounded-md shadow focus:outline-none transition-all duration-200 ease-out transform ${
-        isTooltipVisible
+      className={`absolute z-50 ${isMenuRight ? "right-0" : "left-0"
+        } mt-2 w-56 origin-top-right bg-white divide-y divide-gray-100 rounded-md shadow focus:outline-none transition-all duration-200 ease-out transform ${isTooltipVisible
           ? "opacity-100 scale-100"
           : "opacity-0 scale-95 pointer-events-none"
-      }`}
+        }`}
     >
       {isTooltipVisible && (
         <div className="flex flex-col gap-2">

--- a/src/components/timesheet/timesheet-row/TimeEntryCell.tsx
+++ b/src/components/timesheet/timesheet-row/TimeEntryCell.tsx
@@ -23,6 +23,7 @@ export interface TimeEntryCellProps extends CellProps {
   isInDragRange: boolean;
   type: "task" | "holiday" | "sick" | "finished";
   isColumnView: boolean;
+  readOnly: boolean;
 }
 
 export const TimeEntryCell: React.FC<TimeEntryCellProps> = ({
@@ -35,6 +36,7 @@ export const TimeEntryCell: React.FC<TimeEntryCellProps> = ({
   isInDragRange,
   colors,
   type,
+  readOnly,
   onClick,
 }) => {
   const cellId = `${day.toDateString()}-${taskId}`;

--- a/src/components/timesheet/timesheet-row/TimeSheetRow.tsx
+++ b/src/components/timesheet/timesheet-row/TimeSheetRow.tsx
@@ -25,6 +25,8 @@ export interface TimeSheetRowProps {
   setOpenShortMenu?: (
     value: { startDate: string; endDate: string; taskId: string } | undefined
   ) => void;
+  readOnly: boolean;
+  selectedResourceId: number | null;
 }
 
 export const TimeSheetRow: React.FC<TimeSheetRowProps> = ({
@@ -39,6 +41,8 @@ export const TimeSheetRow: React.FC<TimeSheetRowProps> = ({
   openTimeEntryModalHandler,
   openShortMenu,
   setOpenShortMenu,
+  readOnly,
+  selectedResourceId
 }) => {
   // Generate color once per task row
   const { backgroundColor, borderColor } = useMemo(
@@ -94,6 +98,8 @@ export const TimeSheetRow: React.FC<TimeSheetRowProps> = ({
             openShortMenu={openShortMenu}
             setOpenShortMenu={setOpenShortMenu}
             openTimeEntryModalHandler={() => openTimeEntryModalHandler(task)}
+            readOnly={readOnly}
+            selectedResourceId={selectedResourceId}
           />
           <TimeEntryCell
             day={day}
@@ -105,6 +111,7 @@ export const TimeSheetRow: React.FC<TimeSheetRowProps> = ({
             isColumnHighlighted={isColumnHighlighted(dayIndex)}
             isInDragRange={isCellInDragRange(day, task.id)}
             colors={{ backgroundColor, borderColor }}
+            readOnly={readOnly}
           />
         </div>
       </div>

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -34,11 +34,23 @@ export function useLogout() {
     queryClient.setQueryData(["user", "current"], null);
   };
 
+  const isAuthenticated = !!userQuery.data && !userQuery.isError;
+
+  const isSuperUser = isAuthenticated && userQuery.data?.isSuperuser;
+
+  const userCan = (permissions: string[]) => {
+    if (!isAuthenticated) return false;
+    if (isSuperUser) return true; // Superusers have all permissions
+    const userPermissions = userQuery.data?.permissions || [];
+    return permissions.every((perm) => userPermissions.includes(perm));
+  };
+
   return {
     ...userQuery,
     refreshUser,
     clearUser,
-    isAuthenticated: !!userQuery.data && !userQuery.isError,
+    isAuthenticated,
+    userCan,
   };
 }
 

--- a/src/hooks/useMissions.tsx
+++ b/src/hooks/useMissions.tsx
@@ -1,6 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { MissionInterface } from "../restapi/types";
-import { createMission, getMission, getMissions, getResources, getClients, getProjects, getCountries, getCities } from "../restapi/mission";
+import { 
+    createMission, 
+    getMission, 
+    getMissions, 
+    getResources,
+    getActiveResources,
+    getClients, 
+    getProjects, 
+    getCountries, 
+    getCities 
+} from "../restapi/mission";
 import { AxiosError } from "axios";
 import { useGetCurrentUser } from "./useAuth";
 
@@ -32,6 +42,11 @@ export function useGetMissions() {
 
 export function useGetResources() {
     const resources = useQuery('resources', () => getResources());
+    return resources.data;
+}
+
+export function useGetActiveResources() {
+    const resources = useQuery('activeResources', () => getActiveResources());
     return resources.data;
 }
 

--- a/src/hooks/useTimesheet.tsx
+++ b/src/hooks/useTimesheet.tsx
@@ -16,9 +16,9 @@ import {
   getSpecialReason,
 } from "../restapi/timesheet";
 
-export function useCreateTimeEntry() {
+export function useCreateTimeEntry(selectedResourceId: number | null) {
   const { data: currentUser } = useGetCurrentUser();
-  const resourceId = currentUser?.resource.id;
+  const resourceId = selectedResourceId ? selectedResourceId : currentUser?.resource.id;
   const queryClient = useQueryClient();
   if (resourceId === undefined) {
     throw new Error("Resource ID is undefined");
@@ -48,9 +48,13 @@ export function useCreateTimeEntry() {
   );
 }
 
-export function useGetTimesheet(startDate: string, endDate: string) {
+export function useGetTimesheet(
+  startDate: string, 
+  endDate: string, 
+  selectedResourceId: number | null
+) {
   const { data } = useGetCurrentUser();
-  const resourceId = data?.resource?.id;
+  const resourceId = selectedResourceId ? selectedResourceId : data?.resource?.id;
 
   return useQuery(
     ["timesheet", resourceId, startDate, endDate],

--- a/src/pages/Timesheet.tsx
+++ b/src/pages/Timesheet.tsx
@@ -1,9 +1,14 @@
+import { useState } from "react";
 import Krm3Calendar from "../components/timesheet/Krm3Calendar";
+import SelectResourceComponent from "../components/timesheet/SelectResource";
 
 export default function Timesheet() {
+  const [selectedResourceId, setSelectedResourceId] = useState<number | null>(null);
+
   return (
     <div className="p-8 bg-white">
-      <Krm3Calendar />
+      <SelectResourceComponent setSelectedResourceId={setSelectedResourceId} />
+      <Krm3Calendar selectedResourceId={selectedResourceId} />
     </div>
   );
 }

--- a/src/restapi/mission.ts
+++ b/src/restapi/mission.ts
@@ -37,6 +37,12 @@ export function getResources(profile?: number): Promise<Page<Resource>> {
     return restapi.get<Page<Resource>>(`core/resource/`, { params }).then(res => res.data);
 }
 
+export function getActiveResources(): Promise<Resource[]> {
+    return restapi.get<Resource[]>(`core/resource/active/`)
+        .then(res => res.data)
+        .catch((): Resource[] => []);
+}
+
 export function getClients(): Promise<Page<Client>> {
     return restapi.get<Page<Client>>(`core/client/`).then(res => res.data);
 }

--- a/src/restapi/types.ts
+++ b/src/restapi/types.ts
@@ -40,8 +40,8 @@ export interface Currency {
 
 export interface Page<T> {
   count: number;
-  next: string;
-  previous: string;
+  next: string | null;
+  previous: string | null;
   results: T[];
 }
 
@@ -151,6 +151,7 @@ export interface User {
   profile: ProfileInterface;
   username: string;
   cid: string;
+  permissions: string[] | null;
 }
 
 export interface Task {

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,6 +188,14 @@
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
 
+"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz#7ef769a323e2655e126673bb6d2d6913bbead204"
+  integrity sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==
+  dependencies:
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
+
 "@babel/helper-module-imports@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz#e7f8d20602ebdbf9ebbea0a0751fb0f2a4141715"
@@ -195,14 +203,6 @@
   dependencies:
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
-
-"@babel/helper-module-imports@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz#7ef769a323e2655e126673bb6d2d6913bbead204"
-  integrity sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==
-  dependencies:
-    "@babel/traverse" "^7.27.1"
-    "@babel/types" "^7.27.1"
 
 "@babel/helper-module-transforms@^7.25.9", "@babel/helper-module-transforms@^7.26.0":
   version "7.26.0"
@@ -1042,6 +1042,11 @@
     "@babel/plugin-transform-react-jsx-development" "^7.25.9"
     "@babel/plugin-transform-react-pure-annotations" "^7.25.9"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.18.3":
+  version "7.27.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.4.tgz#a91ec580e6c00c67118127777c316dfd5a5a6abf"
+  integrity sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.8", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
@@ -1200,6 +1205,94 @@
   dependencies:
     tslib "^2.4.0"
 
+"@emotion/babel-plugin@^11.13.5":
+  version "11.13.5"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz#eab8d65dbded74e0ecfd28dc218e75607c4e7bc0"
+  integrity sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/serialize" "^1.3.3"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.2.0"
+
+"@emotion/cache@^11.14.0", "@emotion/cache@^11.4.0":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.14.0.tgz#ee44b26986eeb93c8be82bb92f1f7a9b21b2ed76"
+  integrity sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==
+  dependencies:
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/sheet" "^1.4.0"
+    "@emotion/utils" "^1.4.2"
+    "@emotion/weak-memoize" "^0.4.0"
+    stylis "4.2.0"
+
+"@emotion/hash@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
+  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
+
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
+
+"@emotion/react@^11.8.1":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.14.0.tgz#cfaae35ebc67dd9ef4ea2e9acc6cd29e157dd05d"
+  integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.13.5"
+    "@emotion/cache" "^11.14.0"
+    "@emotion/serialize" "^1.3.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.2.0"
+    "@emotion/utils" "^1.4.2"
+    "@emotion/weak-memoize" "^0.4.0"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.3.tgz#d291531005f17d704d0463a032fe679f376509e8"
+  integrity sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==
+  dependencies:
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/unitless" "^0.10.0"
+    "@emotion/utils" "^1.4.2"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
+  integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
+
+"@emotion/unitless@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
+  integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
+
+"@emotion/use-insertion-effect-with-fallbacks@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz#8a8cb77b590e09affb960f4ff1e9a89e532738bf"
+  integrity sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==
+
+"@emotion/utils@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.2.tgz#6df6c45881fcb1c412d6688a311a98b7f59c1b52"
+  integrity sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
+
+"@emotion/weak-memoize@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
+  integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
+
 "@esbuild/aix-ppc64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz#b87036f644f572efb2b3c75746c97d1d2d87ace8"
@@ -1339,12 +1432,27 @@
   dependencies:
     "@floating-ui/utils" "^0.2.9"
 
+"@floating-ui/core@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.1.tgz#1abc6b157d4a936174f9dbd078278c3a81c8bc6b"
+  integrity sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==
+  dependencies:
+    "@floating-ui/utils" "^0.2.9"
+
 "@floating-ui/dom@^1.0.0":
   version "1.6.13"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.13.tgz#a8a938532aea27a95121ec16e667a7cbe8c59e34"
   integrity sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==
   dependencies:
     "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/dom@^1.0.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.1.tgz#76a4e3cbf7a08edf40c34711cf64e0cc8053d912"
+  integrity sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==
+  dependencies:
+    "@floating-ui/core" "^1.7.1"
     "@floating-ui/utils" "^0.2.9"
 
 "@floating-ui/dom@^1.6.1":
@@ -2252,6 +2360,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.126.tgz#27875faa2926c0f475b39a8bb1e546c0176f8d4b"
   integrity sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==
 
+"@types/parse-json@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
+  integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
+
 "@types/prettier@^2.1.5":
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
@@ -2280,6 +2393,11 @@
   integrity sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==
   dependencies:
     "@types/react" "*"
+
+"@types/react-transition-group@^4.4.0":
+  version "4.4.12"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
+  integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
 "@types/react@*":
   version "19.1.4"
@@ -2654,6 +2772,15 @@ babel-plugin-jest-hoist@^29.6.3:
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-macros@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
+  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cosmiconfig "^7.0.0"
+    resolve "^1.19.0"
+
 babel-plugin-polyfill-corejs2@^0.4.10:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz#7d445f0e0607ebc8fb6b01d7e8fb02069b91dd8b"
@@ -2966,7 +3093,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-convert-source-map@^1.4.0, convert-source-map@^1.6.0:
+convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
@@ -2982,6 +3109,17 @@ core-js-compat@^3.40.0:
   integrity sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==
   dependencies:
     browserslist "^4.24.4"
+
+cosmiconfig@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 cosmiconfig@^8.1.3:
   version "8.3.6"
@@ -3197,7 +3335,7 @@ dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
-dom-helpers@^5.2.0, dom-helpers@^5.2.1:
+dom-helpers@^5.0.1, dom-helpers@^5.2.0, dom-helpers@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -3362,6 +3500,11 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
@@ -3489,6 +3632,11 @@ filter-obj@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
   integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -3700,6 +3848,13 @@ header-case@^2.0.3:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
+hoist-non-react-statics@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -3791,7 +3946,7 @@ iconv-lite@0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-import-fresh@^3.3.0:
+import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
   integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
@@ -5107,7 +5262,7 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-json@^5.2.0:
+parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -5252,7 +5407,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5353,7 +5508,7 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5434,6 +5589,21 @@ react-router@6.30.0:
   dependencies:
     "@remix-run/router" "1.23.0"
 
+react-select@^5.10.1:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.10.1.tgz#e858dd98358ccd864b65d53ab0fb682cd5e96b89"
+  integrity sha512-roPEZUL4aRZDx6DcsD+ZNreVl+fM8VsKn0Wtex1v4IazH60ILp5xhdlp464IsEAlJdXeD+BhDAFsBVMfvLQueA==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@floating-ui/dom" "^1.0.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^6.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+    use-isomorphic-layout-effect "^1.2.0"
+
 react-shallow-renderer@^16.15.0:
   version "16.15.0"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
@@ -5465,6 +5635,16 @@ react-tooltip@^5.28.1:
   dependencies:
     "@floating-ui/dom" "^1.6.1"
     classnames "^2.3.0"
+
+react-transition-group@^4.3.0:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^18.2.0:
   version "18.3.1"
@@ -5578,7 +5758,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.1.tgz#05cfd5b3edf641571fd46fa608b610dda9ead999"
   integrity sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==
 
-resolve@^1.14.2, resolve@^1.20.0:
+resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0:
   version "1.22.10"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
@@ -5793,6 +5973,11 @@ source-map-support@^0.5.6:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -5915,6 +6100,11 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+stylis@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
+  integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
 supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
@@ -6205,6 +6395,11 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-isomorphic-layout-effect@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz#2f11a525628f56424521c748feabc2ffcc962fce"
+  integrity sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==
 
 v8-to-istanbul@^8.1.0:
   version "8.1.1"
@@ -6527,6 +6722,11 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
* installed react-select dep
* set the searchable select on the top of the timesheet page
* upon resource select the timesheet shows the hours for that resource
* default initial selection is on the logged in user
* list of active resources fetched from `/api/resources/active/` if the API call fails for any reason (eg. permission issues) the select is not shown
* Handled edit/view/access-denied time entry scenarios with the following logic:
  * if the time entry belongs to the current user (via the resource ID check) automatically have write/read permission
  * if the time entry belongs to __another user__:
    * write privilege if the user is `suerUser` or have assigned the following permissions:
       * `core.manage_any_project` OR `core.view_any_project`
       * `core.manage_any_timesheet`
    * read only privilege if the user does not fall into the previous case and have assigned the following permissions:
      * `core.manage_any_project` OR `core.view_any_project`
      * `core.view_any_timesheet`
    * access denied if the user does not fall into the previous two cases
   
TODO: Handle the case in which the user does not have a resource model associated (perhaps deny the time-sheet page access??)
