### PR TITLE
fix: prevent theme reset when navigating to non-React pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krm3",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/commons/ThemeProviderWrapper.tsx
+++ b/src/components/commons/ThemeProviderWrapper.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { ThemeProvider } from "next-themes";
+
+const STORAGE_KEY = "theme";
+
+export function ThemeProviderWrapper({ children }: { children: React.ReactNode }) {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "auto") {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY && e.newValue === "auto") {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" storageKey={STORAGE_KEY}>
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,18 +6,13 @@ import { ThemeProvider } from "next-themes";
 
 const root = createRoot(document.getElementById("root") as HTMLElement);
 
+if (localStorage.getItem("theme") === "auto") {
+  localStorage.removeItem("theme");
+}
+
 root.render(
   <React.StrictMode>
-    <ThemeProvider
-      attribute="class"
-      defaultTheme="system"
-      storageKey="theme"
-      value={{
-        light: "light",
-        dark: "dark",
-        system: "auto",
-      }}
-    >
+    <ThemeProvider attribute="class" defaultTheme="system" storageKey="theme">
       <App />
     </ThemeProvider>
   </React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ const root = createRoot(document.getElementById("root") as HTMLElement);
 
 root.render(
   <React.StrictMode>
-    <ThemeProvider attribute="class" defaultTheme="dark">
+    <ThemeProvider attribute="class" defaultTheme="dark" storageKey="krm3-theme">
       <App />
     </ThemeProvider>
   </React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./App";
-import { ThemeProvider } from "next-themes";
+import { ThemeProviderWrapper } from "./components/commons/ThemeProviderWrapper.tsx";
 
 const root = createRoot(document.getElementById("root") as HTMLElement);
 
 root.render(
   <React.StrictMode>
-    <ThemeProvider>
+    <ThemeProviderWrapper>
       <App />
-    </ThemeProvider>
+    </ThemeProviderWrapper>
   </React.StrictMode>
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,16 @@ const root = createRoot(document.getElementById("root") as HTMLElement);
 
 root.render(
   <React.StrictMode>
-    <ThemeProvider attribute="class" defaultTheme="dark" storageKey="krm3-theme">
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      storageKey="theme"
+      value={{
+        light: "light",
+        dark: "dark",
+        system: "auto",
+      }}
+    >
       <App />
     </ThemeProvider>
   </React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,13 +6,9 @@ import { ThemeProvider } from "next-themes";
 
 const root = createRoot(document.getElementById("root") as HTMLElement);
 
-if (localStorage.getItem("theme") === "auto") {
-  localStorage.removeItem("theme");
-}
-
 root.render(
   <React.StrictMode>
-    <ThemeProvider attribute="class" defaultTheme="system" storageKey="theme">
+    <ThemeProvider>
       <App />
     </ThemeProvider>
   </React.StrictMode>


### PR DESCRIPTION
Theme key in localStorage was coliding with theme key from Django. I changed name of theme key for FE.