### PR TITLE
feat(contacts): contact detail actions - edit, delete and toggle active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krm3",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/commons/Krm3Button.tsx
+++ b/src/components/commons/Krm3Button.tsx
@@ -13,31 +13,38 @@ interface Props {
   id?: string;
 }
 
-const Krm3Button = ({ disabled, onClick, type, style, icon, label, disabledTooltipMessage, additionalStyles="", mobileLabel, id }: Props) => {
+const Krm3Button = ({
+  disabled,
+  onClick,
+  type,
+  style,
+  icon,
+  label,
+  disabledTooltipMessage,
+  additionalStyles = "",
+  mobileLabel,
+  id,
+}: Props) => {
   const styles = {
     primary: {
       buttonStyle:
-        "text-white border-transparent bg-krm3-primary hover:bg-krm3-primary-dark focus:outline-none focus:ring-krm3-primary",
-      disabledStyle:
-        "text-white border-transparent bg-krm3-disabled cursor-not-allowed",
+        "text-white border-transparent bg-krm3-primary hover:bg-krm3-primary-dark focus:outline-none focus:ring-krm3-primary cursor-pointer",
+      disabledStyle: "text-white border-transparent bg-krm3-disabled cursor-not-allowed",
     },
     secondary: {
       buttonStyle:
-        "border-krm3-disabled font-medium rounded-md text-gray-600 bg-white hover:bg-gray-50 focus:outline-none focus:ring-krm3-disabled transition-colors duration-200",
-      disabledStyle:
-        "text-white border-transparent bg-krm3-disabled cursor-not-allowed",
+        "border-krm3-disabled font-medium rounded-md text-gray-600 bg-white hover:bg-gray-50 focus:outline-none focus:ring-krm3-disabled transition-colors duration-200 cursor-pointer",
+      disabledStyle: "text-white border-transparent bg-krm3-disabled cursor-not-allowed",
     },
     danger: {
       buttonStyle:
-        "text-white border-transparent bg-krm3-danger hover:bg-krm3-danger-dark focus:outline-none focus:ring-krm3-danger",
-      disabledStyle:
-        "text-white border-transparent bg-krm3-disabled cursor-not-allowed",
+        "text-white border-transparent bg-krm3-danger hover:bg-krm3-danger-dark focus:outline-none focus:ring-krm3-danger cursor-pointer",
+      disabledStyle: "text-white border-transparent bg-krm3-disabled cursor-not-allowed",
     },
     default: {
       buttonStyle:
-        "text-white border-transparent bg-krm3-primary hover:bg-krm3-primary-dark focus:outline-none focus:ring-krm3-primary",
-      disabledStyle:
-        "text-white border-transparent bg-krm3-disabled cursor-not-allowed",
+        "text-white border-transparent bg-krm3-primary hover:bg-krm3-primary-dark focus:outline-none focus:ring-krm3-primary cursor-pointer",
+      disabledStyle: "text-white border-transparent bg-krm3-disabled cursor-not-allowed",
     },
   };
 
@@ -58,18 +65,15 @@ const Krm3Button = ({ disabled, onClick, type, style, icon, label, disabledToolt
       >
         {icon && <span className="mr-2">{icon}</span>}
         {mobileLabel ? (
-            <>
-              <span className="sm:inline hidden">{label}</span>
-              <span className="sm:hidden inline">{mobileLabel}</span>
-            </>
+          <>
+            <span className="sm:inline hidden">{label}</span>
+            <span className="sm:hidden inline">{mobileLabel}</span>
+          </>
         ) : (
-            label
+          label
         )}
-
       </button>
-      {disabled && (
-        <Tooltip id={`tooltip-${label}`} content={disabledTooltipMessage} />
-      )}
+      {disabled && <Tooltip id={`tooltip-${label}`} content={disabledTooltipMessage} />}
     </>
   );
 };

--- a/src/components/commons/krm3Modal.tsx
+++ b/src/components/commons/krm3Modal.tsx
@@ -10,13 +10,7 @@ interface Krm3ModalProps {
   title?: string;
 }
 
-export default function Krm3Modal({
-  open,
-  onClose,
-  children,
-  title,
-  width,
-}: Krm3ModalProps) {
+export default function Krm3Modal({ open, onClose, children, title, width }: Krm3ModalProps) {
   // Handle body scroll lock
   useEffect(() => {
     if (open) {
@@ -32,7 +26,7 @@ export default function Krm3Modal({
   // Modal styles that match original component
   const customStyles = {
     overlay: {
-      backgroundColor: "rgba(0, 0, 0, 0.2)",
+      backgroundColor: "rgba(0, 0, 0, 0.6)",
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -69,11 +63,9 @@ export default function Krm3Modal({
     >
       <div className="relative flex flex-col bg-card">
         <div className="flex justify-between items-center p-4 sm:p-6 border-b-app">
-          <p className="text-xl sm:text-2xl font-semibold text-app">
-            {title}
-          </p>
+          <p className="text-xl sm:text-2xl font-semibold text-app">{title}</p>
           <button
-            className="text-app hover:text-krm3-primary focus:outline-none focus:ring-2 focus:ring-krm3-primary rounded p-1"
+            className="text-app hover:text-krm3-primary focus:outline-none focus:ring-2 focus:ring-krm3-primary rounded p-1 cursor-pointer"
             onClick={onClose}
             aria-label="Close modal"
           >

--- a/src/components/contacts/ContactDetails.tsx
+++ b/src/components/contacts/ContactDetails.tsx
@@ -1,6 +1,16 @@
 import React, { useState } from "react";
 import { ArrowLeft, User, MapPin, Mail, Phone, Globe, LucideIcon } from "lucide-react";
-import { useGetContact } from "../../hooks/useContacts.tsx";
+import { toast } from "react-toastify";
+import {
+  useGetContact,
+  useUpdateContact,
+  useDeleteContact,
+  useToggleContactActive,
+  CreateContactProps,
+} from "../../hooks/useContacts.tsx";
+import { ContactForm } from "./ContactForm.tsx";
+import Krm3Modal from "../commons/krm3Modal.tsx";
+import Krm3Button from "../commons/Krm3Button.tsx";
 import { Address, Email, Phone as PhoneType, Website } from "../../restapi/types.ts";
 
 interface Props {
@@ -24,8 +34,8 @@ function ContactSection<T>({
   emptyMessage,
 }: SectionProps<T>) {
   return (
-    <div className="bg-card-dim rounded-xl p-4 border border-app self-start">
-      <h3 className="text-sm font-bold text-muted uppercase tracking-wide mb-3">
+    <div className="bg-card-dim rounded-xl p-4 border border-app h-full">
+      <h3 className="text-sm font-bold text-muted uppercase tracking-wide !m-0 !mb-3">
         <Icon size={18} className="inline-block mr-2 align-text-bottom" />
         {title}
       </h3>
@@ -43,17 +53,72 @@ function ContactSection<T>({
 }
 
 export function ContactDetails({ contactId, close }: Props): React.ReactElement {
-  const { data: contact, isLoading, error } = useGetContact(contactId);
+  const { data: contact, isLoading, error, refetch } = useGetContact(contactId);
+  const { mutate: updateContact } = useUpdateContact();
+  const { mutate: deleteContact, isLoading: isDeleting } = useDeleteContact();
+  const { mutate: toggleContactActive, isLoading: isTogglingActive } = useToggleContactActive();
   const [activeTab, setActiveTab] = useState<"general" | "notes">("general");
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [isToggleActiveConfirmOpen, setIsToggleActiveConfirmOpen] = useState(false);
 
   if (isLoading) return <div className="p-8">Loading...</div>;
   if (error || !contact) return <div className="p-8 text-red-500">Error loading contact</div>;
 
   const fullName = `${contact.firstName} ${contact.lastName}`.trim();
 
+  const handleEditSubmit = (data: CreateContactProps) => {
+    updateContact(
+      { id: contactId, data },
+      {
+        onSuccess: () => {
+          toast.success("Contact updated successfully");
+          setIsEditModalOpen(false);
+          refetch();
+        },
+        onError: (err) => {
+          toast.error("Failed to update contact");
+          console.error(err);
+        },
+      }
+    );
+  };
+
+  const handleDeleteConfirm = () => {
+    deleteContact(contactId, {
+      onSuccess: () => {
+        toast.success("Contact deleted successfully");
+        close();
+      },
+      onError: (err) => {
+        toast.error("Failed to delete contact");
+        console.error(err);
+      },
+    });
+  };
+
+  const handleToggleActiveConfirm = () => {
+    toggleContactActive(
+      { id: contactId, isActive: !contact.isActive },
+      {
+        onSuccess: () => {
+          toast.success(contact.isActive ? "Contact deactivated" : "Contact activated");
+          setIsToggleActiveConfirmOpen(false);
+          refetch();
+        },
+        onError: (err) => {
+          toast.error(
+            contact.isActive ? "Failed to deactivate contact" : "Failed to activate contact"
+          );
+          console.error(err);
+        },
+      }
+    );
+  };
+
   return (
     <div className="bg-app min-h-full p-4 sm:p-8 flex flex-col items-center">
-      <div className="w-full max-w-5xl mb-4">
+      <div className="w-full max-w-5xl mb-4 flex justify-between items-center">
         <button
           onClick={close}
           id="back-to-general-view"
@@ -62,6 +127,26 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
           <ArrowLeft size={20} className="mr-2" />
           <span className="font-bold text-lg">Back</span>
         </button>
+        <div className="flex gap-2">
+          <Krm3Button
+            id="edit-button"
+            label="Edit"
+            style="secondary"
+            onClick={() => setIsEditModalOpen(true)}
+          />
+          <Krm3Button
+            id="toggle-active-button"
+            label={contact.isActive ? "Deactivate" : "Activate"}
+            style="primary"
+            onClick={() => setIsToggleActiveConfirmOpen(true)}
+          />
+          <Krm3Button
+            id="delete-button"
+            label="Delete"
+            style="danger"
+            onClick={() => setIsDeleteConfirmOpen(true)}
+          />
+        </div>
       </div>
 
       <div className="w-full max-w-5xl bg-card shadow-sm border border-app rounded-2xl min-h-[600px] flex flex-col overflow-hidden">
@@ -127,7 +212,7 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
 
         <div className="p-6 sm:p-10 bg-card">
           {activeTab === "general" && (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
               <ContactSection
                 title="Addresses"
                 icon={MapPin}
@@ -172,6 +257,80 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
           )}
         </div>
       </div>
+
+      <Krm3Modal
+        open={isEditModalOpen}
+        title="Edit Contact"
+        onClose={() => setIsEditModalOpen(false)}
+      >
+        <ContactForm
+          initialData={contact}
+          onSubmit={handleEditSubmit}
+          onCancel={() => setIsEditModalOpen(false)}
+          onSuccess={() => setIsEditModalOpen(false)}
+        />
+      </Krm3Modal>
+
+      <Krm3Modal
+        open={isDeleteConfirmOpen}
+        title="Delete Contact"
+        onClose={() => setIsDeleteConfirmOpen(false)}
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-gray-700">
+            Are you sure you want to delete <strong>{fullName}</strong>? This action cannot be
+            undone.
+          </p>
+          <div className="flex gap-2 justify-end">
+            <Krm3Button
+              label="Cancel"
+              style="secondary"
+              onClick={() => setIsDeleteConfirmOpen(false)}
+            />
+            <Krm3Button
+              id="delete-confirm"
+              label={isDeleting ? "Deleting..." : "Delete"}
+              style="danger"
+              onClick={handleDeleteConfirm}
+            />
+          </div>
+        </div>
+      </Krm3Modal>
+
+      <Krm3Modal
+        open={isToggleActiveConfirmOpen}
+        title={contact.isActive ? "Deactivate Contact" : "Activate Contact"}
+        onClose={() => setIsToggleActiveConfirmOpen(false)}
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-gray-700">
+            Are you sure you want to {contact.isActive ? "deactivate" : "activate"}{" "}
+            <strong>{fullName}</strong>?
+            {contact.isActive && " They will no longer appear in active contacts lists."}
+          </p>
+          <div className="flex gap-2 justify-end">
+            <Krm3Button
+              label="Cancel"
+              style="secondary"
+              onClick={() => setIsToggleActiveConfirmOpen(false)}
+            />
+            <Krm3Button
+              id="toggle-active-confirm"
+              label={
+                isTogglingActive
+                  ? contact.isActive
+                    ? "Deactivating..."
+                    : "Activating..."
+                  : contact.isActive
+                    ? "Deactivate"
+                    : "Activate"
+              }
+              style="primary"
+              onClick={handleToggleActiveConfirm}
+            />
+          </div>
+        </div>
+      </Krm3Modal>
     </div>
   );
 }

--- a/src/components/contacts/ContactDetails.tsx
+++ b/src/components/contacts/ContactDetails.tsx
@@ -56,11 +56,12 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
   const { data: contact, isLoading, error, refetch } = useGetContact(contactId);
   const { mutate: updateContact } = useUpdateContact();
   const { mutate: deleteContact, isLoading: isDeleting } = useDeleteContact();
-  const { mutate: toggleContactActive, isLoading: isTogglingActive } = useToggleContactActive();
+  const { mutate: toggleContactActive } = useToggleContactActive();
   const [activeTab, setActiveTab] = useState<"general" | "notes">("general");
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [isToggleActiveConfirmOpen, setIsToggleActiveConfirmOpen] = useState(false);
+  const [toggleActionLabel, setToggleActionLabel] = useState("Deactivate");
 
   if (isLoading) return <div className="p-8">Loading...</div>;
   if (error || !contact) return <div className="p-8 text-red-500">Error loading contact</div>;
@@ -98,12 +99,12 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
   };
 
   const handleToggleActiveConfirm = () => {
+    setIsToggleActiveConfirmOpen(false);
     toggleContactActive(
       { id: contactId, isActive: !contact.isActive },
       {
         onSuccess: () => {
           toast.success(contact.isActive ? "Contact deactivated" : "Contact activated");
-          setIsToggleActiveConfirmOpen(false);
           refetch();
         },
         onError: (err) => {
@@ -122,7 +123,7 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
         <button
           onClick={close}
           id="back-to-general-view"
-          className="flex items-center text-muted hover:text-app transition-colors"
+          className="flex items-center text-muted hover:text-app transition-colors cursor-pointer"
         >
           <ArrowLeft size={20} className="mr-2" />
           <span className="font-bold text-lg">Back</span>
@@ -138,7 +139,10 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
             id="toggle-active-button"
             label={contact.isActive ? "Deactivate" : "Activate"}
             style="primary"
-            onClick={() => setIsToggleActiveConfirmOpen(true)}
+            onClick={() => {
+              setToggleActionLabel(contact.isActive ? "Deactivate" : "Activate");
+              setIsToggleActiveConfirmOpen(true);
+            }}
           />
           <Krm3Button
             id="delete-button"
@@ -176,7 +180,7 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
             <h1 className="font-normal text-app mb-2">
               {contact.title && (
                 <span className="text-muted text-2xl font-light mr-1">
-                  {contact.title.charAt(0).toUpperCase() + contact.title.slice(1)}.{" "}
+                  {contact.title.charAt(0).toUpperCase() + contact.title.slice(1)}{" "}
                 </span>
               )}
               {fullName}
@@ -190,7 +194,7 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
         <div className="border-b border-app flex px-6 sm:px-10 gap-8">
           <button
             onClick={() => setActiveTab("general")}
-            className={`pb-3 text-sm font-bold border-b-2 transition-colors ${
+            className={`pb-3 text-sm font-bold border-b-2 hover:transition-colors cursor-pointer ${
               activeTab === "general"
                 ? "border-krm3-primary text-app"
                 : "border-transparent text-muted hover:text-app"
@@ -200,7 +204,7 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
           </button>
           <button
             onClick={() => setActiveTab("notes")}
-            className={`pb-3 text-sm font-bold border-b-2 transition-colors ${
+            className={`pb-3 text-sm font-bold border-b-2 hover:transition-colors cursor-pointer ${
               activeTab === "notes"
                 ? "border-krm3-primary text-app"
                 : "border-transparent text-muted hover:text-app"
@@ -225,21 +229,39 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
                 icon={Mail}
                 items={contact.emails}
                 emptyMessage="No emails available."
-                renderItem={(e: Email) => <span className="text-app break-all">{e.address}</span>}
+                renderItem={(e: Email) => (
+                  <a
+                    href={`mailto:${e.address}`}
+                    className="text-krm3-primary hover:underline break-all"
+                  >
+                    {e.address}
+                  </a>
+                )}
               />
               <ContactSection
                 title="Phones"
                 icon={Phone}
                 items={contact.phones}
                 emptyMessage="No phones available."
-                renderItem={(p: PhoneType) => <span className="text-app">{p.number}</span>}
+                renderItem={(p: PhoneType) => (
+                  <a href={`tel:${p.number}`} className="text-krm3-primary hover:underline">
+                    {p.number}
+                  </a>
+                )}
               />
               <ContactSection
                 title="Websites"
                 icon={Globe}
                 items={contact.websites}
                 emptyMessage="No websites available."
-                renderItem={(w: Website) => <span className="text-app break-all">{w.url}</span>}
+                renderItem={(w: Website) => (
+                  <a
+                    href={w.url.startsWith("http") ? w.url : `https://${w.url}`}
+                    className="text-krm3-primary hover:underline break-all"
+                  >
+                    {w.url}
+                  </a>
+                )}
               />
             </div>
           )}
@@ -277,7 +299,7 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
         onClose={() => setIsDeleteConfirmOpen(false)}
       >
         <div className="flex flex-col gap-4">
-          <p className="text-gray-700">
+          <p className="text-app">
             Are you sure you want to delete <strong>{fullName}</strong>? This action cannot be
             undone.
           </p>
@@ -299,14 +321,14 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
 
       <Krm3Modal
         open={isToggleActiveConfirmOpen}
-        title={contact.isActive ? "Deactivate Contact" : "Activate Contact"}
+        title={`${toggleActionLabel} Contact`}
         onClose={() => setIsToggleActiveConfirmOpen(false)}
       >
         <div className="flex flex-col gap-4">
-          <p className="text-gray-700">
-            Are you sure you want to {contact.isActive ? "deactivate" : "activate"}{" "}
-            <strong>{fullName}</strong>?
-            {contact.isActive && " They will no longer appear in active contacts lists."}
+          <p className="text-app">
+            Are you sure you want to {toggleActionLabel.toLowerCase()} <strong>{fullName}</strong>?
+            {toggleActionLabel === "Deactivate" &&
+              " They will no longer appear in active contacts lists."}
           </p>
           <div className="flex gap-2 justify-end">
             <Krm3Button
@@ -316,15 +338,7 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
             />
             <Krm3Button
               id="toggle-active-confirm"
-              label={
-                isTogglingActive
-                  ? contact.isActive
-                    ? "Deactivating..."
-                    : "Activating..."
-                  : contact.isActive
-                    ? "Deactivate"
-                    : "Activate"
-              }
+              label={toggleActionLabel}
               style="primary"
               onClick={handleToggleActiveConfirm}
             />

--- a/src/components/contacts/ContactDetails.tsx
+++ b/src/components/contacts/ContactDetails.tsx
@@ -1,5 +1,15 @@
 import React, { useState } from "react";
-import { ArrowLeft, User, MapPin, Mail, Phone, Globe, LucideIcon } from "lucide-react";
+import {
+  ArrowLeft,
+  User,
+  MapPin,
+  Mail,
+  Phone,
+  Globe,
+  CircleCheck,
+  CircleX,
+  LucideIcon,
+} from "lucide-react";
 import { toast } from "react-toastify";
 import {
   useGetContact,
@@ -154,7 +164,24 @@ export function ContactDetails({ contactId, close }: Props): React.ReactElement 
       </div>
 
       <div className="w-full max-w-5xl bg-card shadow-sm border border-app rounded-2xl min-h-[600px] flex flex-col overflow-hidden">
-        <div className="p-6 sm:p-10 flex flex-col sm:flex-row gap-6 items-center sm:items-start">
+        <div className="relative p-6 sm:p-10 flex flex-col sm:flex-row gap-6 items-center sm:items-start">
+          <div
+            className="absolute top-4 right-4 sm:top-6 sm:right-6 flex items-center gap-1.5 text-sm font-medium"
+            data-testid="contact-status-indicator"
+          >
+            {contact.isActive ? (
+              <>
+                <CircleCheck size={16} className="text-green-600" />
+                <span className="text-green-600">Active</span>
+              </>
+            ) : (
+              <>
+                <CircleX size={16} className="text-red-600" />
+                <span className="text-red-600">Inactive</span>
+              </>
+            )}
+          </div>
+
           <div className="relative shrink-0">
             {contact.picture ? (
               <img

--- a/src/components/contacts/ContactForm.tsx
+++ b/src/components/contacts/ContactForm.tsx
@@ -8,11 +8,14 @@ import {
   useGetClients,
   useGetTitles,
 } from "../../hooks/useContacts.tsx";
+import { Contact } from "../../restapi/types.ts";
 import Krm3Button from "../commons/Krm3Button.tsx";
 
 interface ContactFormProps {
   onSuccess?: () => void;
   onCancel?: () => void;
+  initialData?: Contact;
+  onSubmit?: (data: CreateContactProps) => void;
 }
 
 interface FormErrors {
@@ -22,27 +25,56 @@ interface FormErrors {
   picture?: string[];
 }
 
-export function ContactForm({ onSuccess, onCancel }: ContactFormProps) {
-  const { mutate, isLoading } = useCreateContact();
+export function ContactForm({ onSuccess, onCancel, initialData, onSubmit }: ContactFormProps) {
+  const { mutate: createContact, isLoading: isCreating } = useCreateContact();
   const { data: clients, isLoading: clientsLoading } = useGetClients();
   const { data: titles, isLoading: titlesLoading } = useGetTitles();
   const submitModeRef = useRef<"close" | "add_another">("close");
   const [formErrors, setFormErrors] = useState<FormErrors>({});
 
-  const [form, setForm] = useState<CreateContactProps>({
-    firstName: "",
-    lastName: "",
-    jobTitle: "",
-    title: "",
-    taxId: "",
-    picture: "",
-    company: null,
-    internalNotes: "",
-    emails: [{ address: "", kind: "" }],
-    phones: [{ number: "", kind: "" }],
-    websites: [],
-    addresses: [{ address: "", kind: "" }],
-  });
+  const isEditMode = !!initialData;
+
+  const getInitialForm = (): CreateContactProps => {
+    if (initialData) {
+      return {
+        firstName: initialData.firstName,
+        lastName: initialData.lastName,
+        jobTitle: initialData.jobTitle || "",
+        title: initialData.title || "",
+        taxId: initialData.taxId || "",
+        picture: initialData.picture || "",
+        company: initialData.company?.id ?? null,
+        internalNotes: initialData.internalNotes || "",
+        emails: initialData.emails.length > 0 ? initialData.emails : [{ address: "", kind: "" }],
+        phones: initialData.phones.length > 0 ? initialData.phones : [{ number: "", kind: "" }],
+        websites: initialData.websites,
+        addresses:
+          initialData.addresses.length > 0 ? initialData.addresses : [{ address: "", kind: "" }],
+      };
+    }
+    return {
+      firstName: "",
+      lastName: "",
+      jobTitle: "",
+      title: "",
+      taxId: "",
+      picture: "",
+      company: null,
+      internalNotes: "",
+      emails: [{ address: "", kind: "" }],
+      phones: [{ number: "", kind: "" }],
+      websites: [],
+      addresses: [{ address: "", kind: "" }],
+    };
+  };
+
+  const [form, setForm] = useState<CreateContactProps>(getInitialForm);
+
+  useEffect(() => {
+    if (initialData) {
+      setForm(getInitialForm());
+    }
+  }, [initialData]);
 
   const debouncedPhones = useDebounce(form.phones, 300);
   const debouncedEmails = useDebounce(form.emails, 300);
@@ -225,7 +257,16 @@ export function ContactForm({ onSuccess, onCancel }: ContactFormProps) {
       addresses: form.addresses.filter((a) => a.address.trim() !== ""),
       websites: form.websites.filter((w) => w.url.trim() !== ""),
     };
-    mutate(cleaned, {
+
+    if (onSubmit) {
+      onSubmit(cleaned);
+      if (isEditMode) {
+        onSuccess?.();
+      }
+      return;
+    }
+
+    createContact(cleaned, {
       onSuccess: () => {
         toast.success("Contact created successfully");
         setForm({
@@ -490,15 +531,25 @@ export function ContactForm({ onSuccess, onCancel }: ContactFormProps) {
       </div>
       <div className="flex gap-2 justify-end pt-2">
         <Krm3Button label="Cancel" style="secondary" onClick={onCancel} />
+        {!isEditMode && (
+          <Krm3Button
+            type="submit"
+            style="secondary"
+            label={isCreating ? "Creating..." : "Create and add another"}
+            onClick={() => (submitModeRef.current = "add_another")}
+          />
+        )}
         <Krm3Button
           type="submit"
-          style="secondary"
-          label={isLoading ? "Creating..." : "Create and add another"}
-          onClick={() => (submitModeRef.current = "add_another")}
-        />
-        <Krm3Button
-          type="submit"
-          label={isLoading ? "Creating..." : "Create contact"}
+          label={
+            isCreating
+              ? isEditMode
+                ? "Updating..."
+                : "Creating..."
+              : isEditMode
+                ? "Update contact"
+                : "Create contact"
+          }
           onClick={() => (submitModeRef.current = "close")}
         />
       </div>

--- a/src/components/contacts/ContactGridTile.test.tsx
+++ b/src/components/contacts/ContactGridTile.test.tsx
@@ -34,4 +34,11 @@ describe("ContactGridTile", () => {
     renderTile({ ...contact, picture: undefined });
     expect(screen.getByTestId("user-picture-placeholder-1")).toBeInTheDocument();
   });
+
+  it("applies dim styling for inactive contact", () => {
+    renderTile({ ...contact, isActive: false });
+    const tile = screen.getByTestId("contact-grid-tile-1");
+    expect(tile.className).toContain("bg-card-dim");
+    expect(tile.className).toContain("opacity-70");
+  });
 });

--- a/src/components/contacts/ContactGridTile.tsx
+++ b/src/components/contacts/ContactGridTile.tsx
@@ -36,9 +36,9 @@ const ContactGridTile = (props: Props) => {
   return (
     <Link
       to={`/contacts/${contact.id}`}
-      className="bg-card rounded-2xl p-4 sm:p-6 border border-app shadow-sm
+      className={`rounded-2xl p-4 sm:p-6 border border-app shadow-sm
                  hover:border-krm3-primary hover:shadow-md transition-all
-                 flex flex-col gap-4"
+                 flex flex-col gap-4 ${contact.isActive ? "bg-card" : "bg-card-dim opacity-70"}`}
       id={`contact-grid-tile-${contact.id}`}
       data-testid={`contact-grid-tile-${contact.id}`}
     >

--- a/src/components/contacts/ContactListTile.test.tsx
+++ b/src/components/contacts/ContactListTile.test.tsx
@@ -28,4 +28,15 @@ describe("ContactListTile", () => {
     expect(screen.getByText("123 Main St")).toBeInTheDocument();
     expect(screen.getByText("john@test.com")).toBeInTheDocument();
   });
+
+  it("applies dim styling for inactive contact", () => {
+    render(
+      <MemoryRouter>
+        <ContactListTile contact={{ ...contact, isActive: false }} />
+      </MemoryRouter>
+    );
+    const tile = screen.getByTestId("contact-list-tile-1");
+    expect(tile.className).toContain("bg-card-dim");
+    expect(tile.className).toContain("opacity-70");
+  });
 });

--- a/src/components/contacts/ContactListTile.tsx
+++ b/src/components/contacts/ContactListTile.tsx
@@ -17,10 +17,10 @@ const ContactListTile = (props: Props) => {
   return (
     <Link
       to={`/contacts/${contact.id}`}
-      className="bg-card rounded-xl p-3 border border-app
+      className={`rounded-xl p-3 border border-app
                  hover:border-krm3-primary hover:bg-card-dim transition-all
                  grid grid-cols-[auto_2fr_2fr] md:grid-cols-[auto_2fr_2fr_2fr_2fr]
-                 items-center gap-4"
+                 items-center gap-4 ${contact.isActive ? "bg-card" : "bg-card-dim opacity-70"}`}
       id={`contact-list-tile-${contact.id}`}
       data-testid={`contact-list-tile-${contact.id}`}
     >

--- a/src/hooks/useContacts.tsx
+++ b/src/hooks/useContacts.tsx
@@ -4,6 +4,9 @@ import {
   getContacts,
   getContact,
   createContact,
+  updateContact,
+  deleteContact,
+  toggleContactActive,
   getTitles,
 } from "../restapi/contacts.ts";
 import { Address, Contact, Email, Phone, Website } from "../restapi/types.ts";
@@ -76,4 +79,52 @@ export function useGetTitles() {
       console.error("Titles fetch failed:", error);
     },
   });
+}
+
+export function useUpdateContact() {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    ({ id, data }: { id: number; data: CreateContactProps }) =>
+      updateContact(id, data as Partial<Contact>),
+    {
+      onSuccess: (_, { id }) => {
+        queryClient.invalidateQueries({ queryKey: ["contacts"] });
+        queryClient.invalidateQueries({ queryKey: ["contact", id] });
+      },
+      onError: (error) => {
+        console.error("Contact update failed:", error);
+      },
+    }
+  );
+}
+
+export function useDeleteContact() {
+  const queryClient = useQueryClient();
+
+  return useMutation((id: number) => deleteContact(id), {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["contacts"] });
+    },
+    onError: (error) => {
+      console.error("Contact delete failed:", error);
+    },
+  });
+}
+
+export function useToggleContactActive() {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    ({ id, isActive }: { id: number; isActive: boolean }) => toggleContactActive(id, isActive),
+    {
+      onSuccess: (_, { id }) => {
+        queryClient.invalidateQueries({ queryKey: ["contacts"] });
+        queryClient.invalidateQueries({ queryKey: ["contact", id] });
+      },
+      onError: (error) => {
+        console.error("Contact toggle active failed:", error);
+      },
+    }
+  );
 }

--- a/src/pages/ContactDetailsPage.test.tsx
+++ b/src/pages/ContactDetailsPage.test.tsx
@@ -105,7 +105,7 @@ describe("ContactDetailsPage", () => {
       } as unknown as ReturnType<typeof useContacts.useGetContact>;
     });
     renderDetails("2");
-    expect(screen.getByRole("heading", { name: /Doctor\.\s+Jack Sparrow/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Doctor\s+Jack Sparrow/ })).toBeInTheDocument();
   });
 
   it("shows error or fallback when ID is invalid", () => {

--- a/src/pages/ContactDetailsPage.test.tsx
+++ b/src/pages/ContactDetailsPage.test.tsx
@@ -1,9 +1,17 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import * as useGetContacts from "../hooks/useContacts.tsx";
+import { QueryClient, QueryClientProvider } from "react-query";
+import * as useContacts from "../hooks/useContacts.tsx";
 import ContactDetailsPage from "./ContactDetailsPage.tsx";
 import { Contact } from "../restapi/types.ts";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+  },
+});
 
 const mockContacts = [
   {
@@ -18,26 +26,66 @@ const mockContacts = [
     emails: [{ address: "capitan.jack@gmail.com" }],
     websites: [],
   },
+  {
+    firstName: "John",
+    lastName: "Doe",
+    jobTitle: "Software developer",
+    internalNotes: "",
+    isActive: true,
+    id: 1,
+    addresses: [],
+    phones: [],
+    emails: [],
+    websites: [],
+  },
 ] as Contact[];
 
 describe("ContactDetailsPage", () => {
+  let toggleContactActiveMutate = vi.fn();
+  let deleteContactMutate = vi.fn();
+
   beforeEach(() => {
-    vi.spyOn(useGetContacts, "useGetContact").mockImplementation((id: number | null) => {
+    vi.clearAllMocks();
+    toggleContactActiveMutate = vi.fn((_vars, options) => options?.onSuccess?.());
+    deleteContactMutate = vi.fn((_id, options) => options?.onSuccess?.());
+
+    vi.spyOn(useContacts, "useGetContact").mockImplementation((id: number | null) => {
       return {
         data: mockContacts.find((c) => c.id === id),
         isLoading: false,
         error: null,
-      } as ReturnType<typeof useGetContacts.useGetContact>;
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useContacts.useGetContact>;
+    });
+
+    vi.spyOn(useContacts, "useToggleContactActive").mockImplementation(() => {
+      return {
+        mutate: toggleContactActiveMutate,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useContacts.useToggleContactActive>;
+    });
+
+    vi.spyOn(useContacts, "useDeleteContact").mockImplementation(() => {
+      return {
+        mutate: deleteContactMutate,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useContacts.useDeleteContact>;
     });
   });
 
   const renderDetails = (id: string) => {
     render(
-      <MemoryRouter initialEntries={[`/contacts/${id}`]}>
-        <Routes>
-          <Route path="/contacts/:id" element={<ContactDetailsPage />} />
-        </Routes>
-      </MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/contacts/${id}`]}>
+          <Routes>
+            <Route
+              path="/contacts"
+              element={<div data-testid="contacts-list">Contacts list</div>}
+            />
+            <Route path="/contacts/:id" element={<ContactDetailsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
     );
   };
 
@@ -48,12 +96,13 @@ describe("ContactDetailsPage", () => {
   });
 
   it("renders title before name when present", () => {
-    vi.spyOn(useGetContacts, "useGetContact").mockImplementation(() => {
+    vi.spyOn(useContacts, "useGetContact").mockImplementation(() => {
       return {
         data: { ...mockContacts[0], title: "doctor", id: 2 },
         isLoading: false,
         error: null,
-      } as ReturnType<typeof useGetContacts.useGetContact>;
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useContacts.useGetContact>;
     });
     renderDetails("2");
     expect(screen.getByRole("heading", { name: /Doctor\.\s+Jack Sparrow/ })).toBeInTheDocument();
@@ -62,5 +111,65 @@ describe("ContactDetailsPage", () => {
   it("shows error or fallback when ID is invalid", () => {
     renderDetails("invalid");
     expect(screen.getByText("Invalid Contact ID")).toBeInTheDocument();
+  });
+
+  it("shows Activate button for inactive contact and activates on confirm", async () => {
+    renderDetails("2");
+
+    expect(screen.getByTestId("toggle-active-button")).toHaveTextContent("Activate");
+
+    await userEvent.click(screen.getByTestId("toggle-active-button"));
+    expect(screen.getByText("Activate Contact")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("toggle-active-confirm"));
+
+    await waitFor(() => {
+      expect(toggleContactActiveMutate).toHaveBeenCalledWith(
+        { id: 2, isActive: true },
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("shows Deactivate button for active contact and deactivates on confirm", async () => {
+    renderDetails("1");
+
+    expect(screen.getByTestId("toggle-active-button")).toHaveTextContent("Deactivate");
+
+    await userEvent.click(screen.getByTestId("toggle-active-button"));
+    expect(screen.getByText("Deactivate Contact")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("toggle-active-confirm"));
+
+    await waitFor(() => {
+      expect(toggleContactActiveMutate).toHaveBeenCalledWith(
+        { id: 1, isActive: false },
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("opens edit contact modal when Edit is clicked", async () => {
+    renderDetails("2");
+
+    await userEvent.click(screen.getByTestId("edit-button"));
+
+    expect(screen.getByRole("dialog", { name: "Edit Contact" })).toBeInTheDocument();
+    expect(screen.getByText("First Name")).toBeInTheDocument();
+  });
+
+  it("deletes contact and navigates back to contacts list on confirm", async () => {
+    renderDetails("2");
+
+    await userEvent.click(screen.getByTestId("delete-button"));
+    expect(screen.getByText("Delete Contact")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("delete-confirm"));
+
+    await waitFor(() => {
+      expect(deleteContactMutate).toHaveBeenCalledWith(2, expect.any(Object));
+    });
+
+    expect(screen.getByTestId("contacts-list")).toBeInTheDocument();
   });
 });

--- a/src/pages/Contacts.test.tsx
+++ b/src/pages/Contacts.test.tsx
@@ -1,234 +1,243 @@
-import {fireEvent, render, screen, act} from "@testing-library/react";
-import {vi} from "vitest"
-import {MemoryRouter, Route, Routes} from "react-router-dom";
+import { fireEvent, render, screen, act } from "@testing-library/react";
+import { vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 import * as useGetContacts from "../hooks/useContacts.tsx";
 import Contacts from "./Contacts.tsx";
-import {Contact} from "../restapi/types.ts";
+import { Contact, Page } from "../restapi/types.ts";
+import { UseQueryResult } from "react-query";
 
 const mockContacts = [
-    {
-        firstName: "John",
-        lastName: "Doe",
-        jobTitle: "Software developer",
-        internalNotes: "",
-        picture: "example.url",
-        isActive: true,
-        id: 1,
-        addresses: [{
-            address: "New York, Funny Street 11/222",
-        }],
-        phones: [],
-        emails: [],
-        websites: [],
-        company: {
-            id: 1,
-            name: "singlewave",
-            picture: "path/to/picture.jpg",
-        }
+  {
+    firstName: "John",
+    lastName: "Doe",
+    jobTitle: "Software developer",
+    internalNotes: "",
+    picture: "example.url",
+    isActive: true,
+    id: 1,
+    addresses: [
+      {
+        address: "New York, Funny Street 11/222",
+      },
+    ],
+    phones: [],
+    emails: [],
+    websites: [],
+    company: {
+      id: 1,
+      name: "singlewave",
+      picture: "path/to/picture.jpg",
     },
-    {
-        firstName: "Jack",
-        lastName: "Sparrow",
-        jobTitle: "Pirate",
-        internalNotes: "",
-        isActive: false,
-        id: 2,
-        addresses: [],
-        phones: [
-            {
-                number: "+48 111 111 111",
-            }
-        ],
-        emails: [
-            {
-                address: "capitan.jack@gmail.com",
-            }
-        ],
-        websites: []
-    }
+  },
+  {
+    firstName: "Jack",
+    lastName: "Sparrow",
+    jobTitle: "Pirate",
+    internalNotes: "",
+    isActive: false,
+    id: 2,
+    addresses: [],
+    phones: [
+      {
+        number: "+48 111 111 111",
+      },
+    ],
+    emails: [
+      {
+        address: "capitan.jack@gmail.com",
+      },
+    ],
+    websites: [],
+  },
 ] as Contact[];
 
-describe('Contact Page', () => {
-    beforeEach(() => {
-        vi.useFakeTimers();
-        vi.spyOn(useGetContacts, "useGetContacts").mockImplementation((params) => {
-            let results = [...mockContacts];
-            if (params?.active) {
-                results = results.filter(c => c.isActive);
-            }
-            if (params?.search) {
-                const query = params.search.toLowerCase();
-                results = results.filter(c =>
-                    c.firstName.toLowerCase().includes(query) ||
-                    c.lastName.toLowerCase().includes(query) ||
-                    `${c.firstName} ${c.lastName}`.toLowerCase().includes(query)
-                );
-            }
-
-            const page = params?.page || 1;
-            const next = page === 1 ? "http://api/contacts?page=2" : null;
-            const previous = page > 1 ? "http://api/contacts?page=1" : null;
-
-            return {
-                data: {results, count: 20, next, previous},
-                isLoading: false
-            } as any;
-        });
-    });
-
-    afterEach(() => {
-        vi.useRealTimers();
-        vi.restoreAllMocks();
-    });
-
-    const renderContacts = () => {
-        render(
-            <MemoryRouter initialEntries={['/contacts']}>
-                <Routes>
-                    <Route path="/contacts" element={<Contacts/>}/>
-                </Routes>
-            </MemoryRouter>
+describe("Contact Page", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(useGetContacts, "useGetContacts").mockImplementation((params) => {
+      let results = [...mockContacts];
+      if (params?.active) {
+        results = results.filter((c) => c.isActive);
+      }
+      if (params?.search) {
+        const query = params.search.toLowerCase();
+        results = results.filter(
+          (c) =>
+            c.firstName.toLowerCase().includes(query) ||
+            c.lastName.toLowerCase().includes(query) ||
+            `${c.firstName} ${c.lastName}`.toLowerCase().includes(query)
         );
-    };
+      }
 
-    it('renders correctly', () => {
-        renderContacts();
-        expect(screen.getByTestId("contact-grid-tile-1")).toBeInTheDocument();
-        expect(screen.getByTestId("contact-grid-tile-2")).toBeInTheDocument();
-        expect(screen.getByText("John Doe")).toBeInTheDocument();
-        expect(screen.getByText("Jack Sparrow")).toBeInTheDocument();
+      const page = params?.page || 1;
+      const next = page === 1 ? "http://api/contacts?page=2" : null;
+      const previous = page > 1 ? "http://api/contacts?page=1" : null;
+
+      return {
+        data: { results, count: 20, next, previous } as Page<Contact>,
+        isLoading: false,
+      } as UseQueryResult<Page<Contact>>;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const renderContacts = () => {
+    render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<Contacts />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+
+  it("renders correctly with active filter by default", () => {
+    renderContacts();
+    expect(screen.getByTestId("contact-grid-tile-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("contact-grid-tile-2")).not.toBeInTheDocument();
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
+  });
+
+  it("list view shows active contacts by default", () => {
+    renderContacts();
+    fireEvent.click(screen.getByTestId("switch-list-grid"));
+    expect(screen.getByTestId("contact-list-tile-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("contact-list-tile-2")).not.toBeInTheDocument();
+  });
+
+  it("filter all contacts", () => {
+    renderContacts();
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("switch-active"));
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("Jack Sparrow")).toBeInTheDocument();
+  });
+
+  it("pagination next page", () => {
+    renderContacts();
+
+    const nextButton = screen.getByLabelText("Next Page");
+    expect(nextButton).not.toBeDisabled();
+
+    fireEvent.click(nextButton);
+
+    expect(screen.getByText("Page 2")).toBeInTheDocument();
+  });
+
+  it("pagination previous page", () => {
+    renderContacts();
+
+    fireEvent.click(screen.getByLabelText("Next Page"));
+    expect(screen.getByText("Page 2")).toBeInTheDocument();
+
+    const prevButton = screen.getByLabelText("Previous Page");
+    expect(prevButton).not.toBeDisabled();
+
+    fireEvent.click(prevButton);
+
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+  });
+
+  it("Search works first name", () => {
+    renderContacts();
+    const searchBar = screen.getByRole("textbox");
+    fireEvent.change(searchBar, { target: { value: "John" } });
+
+    // Flush the 300ms debounce
+    act(() => {
+      vi.advanceTimersByTime(300);
     });
 
-    it('list view', () => {
-        renderContacts();
-        fireEvent.click(screen.getByTestId("switch-list-grid"));
-        expect(screen.getByTestId("contact-list-tile-1")).toBeInTheDocument();
-        expect(screen.getByTestId("contact-list-tile-2")).toBeInTheDocument();
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
+  });
+
+  it("Search works last name across all contacts", () => {
+    renderContacts();
+    fireEvent.click(screen.getByTestId("switch-active"));
+
+    const searchBar = screen.getByRole("textbox");
+    fireEvent.change(searchBar, { target: { value: "Sparrow" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
     });
 
-    it('filter active', () => {
-        renderContacts();
-        fireEvent.click(screen.getByTestId("switch-active"));
-        expect(screen.getByText("John Doe")).toBeInTheDocument();
-        expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
+    expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
+    expect(screen.getByText("Jack Sparrow")).toBeInTheDocument();
+  });
+
+  it("Search works first name and last name", () => {
+    renderContacts();
+    const searchBar = screen.getByRole("textbox");
+    fireEvent.change(searchBar, { target: { value: "John Doe" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
     });
 
-    it('pagination next page', () => {
-        renderContacts();
-        
-        const nextButton = screen.getByLabelText("Next Page");
-        expect(nextButton).not.toBeDisabled();
-        
-        fireEvent.click(nextButton);
-        
-        expect(screen.getByText("Page 2")).toBeInTheDocument();
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
+  });
+
+  it("Can see all contacts if search cleared again", () => {
+    renderContacts();
+    fireEvent.click(screen.getByTestId("switch-active"));
+    const searchBar = screen.getByRole("textbox");
+
+    // Type a search query
+    fireEvent.change(searchBar, { target: { value: "John" } });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
+
+    // Clear the search
+    fireEvent.change(searchBar, { target: { value: "" } });
+    act(() => {
+      vi.advanceTimersByTime(300);
     });
 
-    it('pagination previous page', () => {
-        renderContacts();
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("Jack Sparrow")).toBeInTheDocument();
+  });
 
-        fireEvent.click(screen.getByLabelText("Next Page"));
-        expect(screen.getByText("Page 2")).toBeInTheDocument();
+  it("Search resets pagination to page 1", () => {
+    renderContacts();
 
-        const prevButton = screen.getByLabelText("Previous Page");
-        expect(prevButton).not.toBeDisabled();
+    // Navigate to page 2
+    fireEvent.click(screen.getByLabelText("Next Page"));
+    expect(screen.getByText("Page 2")).toBeInTheDocument();
 
-        fireEvent.click(prevButton);
-        
-        expect(screen.getByText("Page 1")).toBeInTheDocument();
+    // Typing in the search bar should reset to page 1
+    const searchBar = screen.getByRole("textbox");
+    fireEvent.change(searchBar, { target: { value: "John" } });
+    act(() => {
+      vi.advanceTimersByTime(300);
     });
 
-    it('Search works first name', () => {
-        renderContacts();
-        const searchBar = screen.getByRole("textbox");
-        fireEvent.change(searchBar, {target: {value: "John"}});
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+  });
 
-        // Flush the 300ms debounce
-        act(() => {
-            vi.advanceTimersByTime(300);
-        });
+  it("Search works in list view", () => {
+    renderContacts();
+    fireEvent.click(screen.getByTestId("switch-list-grid"));
 
-        expect(screen.getByText("John Doe")).toBeInTheDocument();
-        expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
+    const searchBar = screen.getByRole("textbox");
+    fireEvent.change(searchBar, { target: { value: "John" } });
+    act(() => {
+      vi.advanceTimersByTime(300);
     });
 
-    it('Search works last name', () => {
-        renderContacts();
-        const searchBar = screen.getByRole("textbox");
-        fireEvent.change(searchBar, {target: {value: "Sparrow"}});
-
-        act(() => {
-            vi.advanceTimersByTime(300);
-        });
-
-        expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
-        expect(screen.getByText("Jack Sparrow")).toBeInTheDocument();
-    });
-
-    it('Search works first name and last name', () => {
-        renderContacts();
-        const searchBar = screen.getByRole("textbox");
-        fireEvent.change(searchBar, {target: {value: "John Doe"}});
-
-        act(() => {
-            vi.advanceTimersByTime(300);
-        });
-
-        expect(screen.getByText("John Doe")).toBeInTheDocument();
-        expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
-    });
-
-    it('Can see all contacts if search cleared again', () => {
-        renderContacts();
-        const searchBar = screen.getByRole("textbox");
-
-        // Type a search query
-        fireEvent.change(searchBar, {target: {value: "John"}});
-        act(() => {
-            vi.advanceTimersByTime(300);
-        });
-        expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
-
-        // Clear the search
-        fireEvent.change(searchBar, {target: {value: ""}});
-        act(() => {
-            vi.advanceTimersByTime(300);
-        });
-
-        expect(screen.getByText("John Doe")).toBeInTheDocument();
-        expect(screen.getByText("Jack Sparrow")).toBeInTheDocument();
-    });
-
-    it('Search resets pagination to page 1', () => {
-        renderContacts();
-
-        // Navigate to page 2
-        fireEvent.click(screen.getByLabelText("Next Page"));
-        expect(screen.getByText("Page 2")).toBeInTheDocument();
-
-        // Typing in the search bar should reset to page 1
-        const searchBar = screen.getByRole("textbox");
-        fireEvent.change(searchBar, {target: {value: "John"}});
-        act(() => {
-            vi.advanceTimersByTime(300);
-        });
-
-        expect(screen.getByText("Page 1")).toBeInTheDocument();
-    });
-
-    it('Search works in list view', () => {
-        renderContacts();
-        fireEvent.click(screen.getByTestId("switch-list-grid"));
-
-        const searchBar = screen.getByRole("textbox");
-        fireEvent.change(searchBar, {target: {value: "John"}});
-        act(() => {
-            vi.advanceTimersByTime(300);
-        });
-
-         expect(screen.getByText("John Doe")).toBeInTheDocument();
-         expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
-    });
-
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Jack Sparrow")).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/Contacts.tsx
+++ b/src/pages/Contacts.tsx
@@ -10,7 +10,7 @@ import Krm3Button from "../components/commons/Krm3Button.tsx";
 
 export default function Contacts() {
   const [isGridView, setIsGridView] = useState(true);
-  const [onlyActiveSelected, setOnlyActiveSelected] = useState(false);
+  const [onlyActiveSelected, setOnlyActiveSelected] = useState(true);
   const [page, setPage] = useState(1);
   const [searchBarValue, setSearchBarValue] = useState("");
   const debouncedSearch = useDebounce(searchBarValue, 300);
@@ -55,14 +55,14 @@ export default function Contacts() {
             Row
           </div>
           <div className="flex flex-row mt-2 ml-10">
-            All
+            Active
             <div className="relative inline-block w-11 h-5 mx-1">
               <input
                 id="switch-active"
                 data-testid="switch-active"
                 type="checkbox"
                 className="peer appearance-none w-11 h-5 bg-slate-200 rounded-full checked:bg-slate-400 cursor-pointer transition-colors duration-300"
-                checked={onlyActiveSelected}
+                checked={!onlyActiveSelected}
                 onChange={() => {
                   setOnlyActiveSelected(!onlyActiveSelected);
                   setPage(1);
@@ -73,7 +73,7 @@ export default function Contacts() {
                 className="absolute top-0 left-0 w-5 h-5 bg-card rounded-full border border-app shadow-sm transition-transform duration-300 peer-checked:translate-x-6 peer-checked:border-slate-800 cursor-pointer"
               />
             </div>
-            Active
+            All
           </div>
           <div className="flex flex-row mt-2 ml-10">
             Search:

--- a/src/restapi/contacts.test.ts
+++ b/src/restapi/contacts.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AxiosResponse } from "axios";
-import { createContact, getContacts, getContact, getClients } from "./contacts";
+import {
+  createContact,
+  getContacts,
+  getContact,
+  getClients,
+  toggleContactActive,
+} from "./contacts";
 import { restapi } from "./restapi";
 import type { Contact } from "./types";
 
@@ -8,6 +14,7 @@ vi.mock("./restapi", () => ({
   restapi: {
     get: vi.fn(),
     post: vi.fn(),
+    patch: vi.fn(),
   },
 }));
 
@@ -185,6 +192,53 @@ describe("createContact", () => {
 
     expect(restapi.post).toHaveBeenCalledWith("core/contacts/", expect.any(Object));
     expect(result).toEqual(contactMock);
+  });
+});
+
+describe("toggleContactActive", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const contactMock: Contact = {
+    id: 1,
+    firstName: "John",
+    lastName: "Doe",
+    jobTitle: "Software developer",
+    internalNotes: "",
+    picture: "example.url",
+    isActive: true,
+    addresses: [],
+    phones: [],
+    emails: [],
+    websites: [],
+    company: {
+      id: 1,
+      name: "singlewave",
+      picture: "path/to/picture.jpg",
+    },
+  };
+
+  it("should PATCH isActive to false", async () => {
+    vi.mocked(restapi.patch).mockResolvedValueOnce({ data: contactMock } as AxiosResponse);
+
+    const result = await toggleContactActive(1, false);
+
+    expect(restapi.patch).toHaveBeenCalledOnce();
+    expect(restapi.patch).toHaveBeenCalledWith("core/contacts/1/", { isActive: false });
+    expect(result).toEqual(contactMock);
+  });
+
+  it("should PATCH isActive to true", async () => {
+    vi.mocked(restapi.patch).mockResolvedValueOnce({
+      data: { ...contactMock, isActive: true },
+    } as AxiosResponse);
+
+    const result = await toggleContactActive(2, true);
+
+    expect(restapi.patch).toHaveBeenCalledOnce();
+    expect(restapi.patch).toHaveBeenCalledWith("core/contacts/2/", { isActive: true });
+    expect(result.isActive).toBe(true);
   });
 });
 

--- a/src/restapi/contacts.ts
+++ b/src/restapi/contacts.ts
@@ -23,6 +23,24 @@ export function createContact(data: Partial<Contact>): Promise<Contact> {
   });
 }
 
+export function updateContact(id: number, data: Partial<Contact>): Promise<Contact> {
+  return restapi.put(`core/contacts/${id}/`, data).then((res) => {
+    return res.data;
+  });
+}
+
+export function deleteContact(id: number): Promise<void> {
+  return restapi.delete(`core/contacts/${id}/`).then((res) => {
+    return res.data;
+  });
+}
+
+export function toggleContactActive(id: number, isActive: boolean): Promise<Contact> {
+  return restapi.patch(`core/contacts/${id}/`, { isActive }).then((res) => {
+    return res.data;
+  });
+}
+
 export function getClients(): Promise<Client[]> {
   return restapi.get(`core/client/`).then((res) => res.data.results);
 }


### PR DESCRIPTION
***Description:***
This PR adds the missing contact detail actions and improves the contact detail layout.

### What's changed
- Added **Edit**, **Delete** and **Activate/Deactivate** buttons to the contact detail header.
- Clicking **Edit** opens the `ContactForm` pre-filled with the existing contact data.
- Clicking **Delete** shows a confirmation modal; on success the user is navigated back to the contacts list.
- Toggle active state via `PATCH /contacts/{id}/` and stay on the detail page after success.
- UI polish:
  - Contact section cards now stretch to fill the grid row height.
  - Removed the default top margin from section headings.
- Added/updated tests for activate/deactivate, edit modal, and delete flows.
